### PR TITLE
Speed up bazaar by simulating bzr root with bash

### DIFF
--- a/bash/bash_vcs.sh
+++ b/bash/bash_vcs.sh
@@ -84,7 +84,15 @@ __prompt_command() {
 	}
 
 	bzr_dir() {
-		base_dir=$(bzr root 2>/dev/null) || return 1
+		# bzr root is really slow, so we simulate it
+        	# with a bash script I modified frome here:
+        	# http://unix.stackexchange.com/questions/6463/find-searching-in-parent-directories-instead-of-subdirectories
+		bzr_root=$(pwd -P 2>/dev/null || command pwd)
+        	while [ ! -e "$bzr_root/.bzr" ]; do
+            		bzr_root=${bzr_root%/*}
+            		if [ "$bzr_root" = "" ]; then break; fi
+        	done
+		base_dir=$bzr_root || return 1
 		if [ -n "$base_dir" ]; then
 			base_dir=`cd $base_dir; pwd`
 		else


### PR DESCRIPTION
The PS1 line took forever (~1s) to display in bzr branches, because bzr is slow.

I increased the speed by eliminating the call to bzr, and replacing it with a modified bash script which I found here:
http://unix.stackexchange.com/questions/6463/find-searching-in-parent-directories-instead-of-subdirectories